### PR TITLE
Update hawk@2.12.0.rb - fix deployed version url

### DIFF
--- a/hawk@2.12.0.rb
+++ b/hawk@2.12.0.rb
@@ -1,7 +1,7 @@
 class HawkAT2120 < Formula
   desc "KaaKaww! Helping developers to find, triage and fix security bugs!"
   homepage "https://www.stackhawk.com/"
-  url "https://download.stackhawk.com/hawk/cli/hawk-${version}.zip"
+  url "https://download.stackhawk.com/hawk/cli/hawk-2.12.0.zip"
   sha256 "961f52db36abfd274d1a7aee0d384eca77f3c181a205c119ec01b51b4029bdb6"
   license ""
 


### PR DESCRIPTION
automation deployment of HawkScan 2.12.0 failed to interpolate a value after some build-system updates.
fixes the 2.12.0 brew cli deployment 