### PR TITLE
docs: add HawkOp install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
-
 # StackHawk CLI Homebrew formulae
 
-This repository hosts the [homebrew](https://brew.sh/) formulae for the StackHawk CLI. 
+This repository hosts the [Homebrew](https://brew.sh/) formulae for the StackHawk CLI tools.
 
-To learn more see the [documentation](https://docs.stackhawk.com/stackhawk-cli).   
+To learn more see the [documentation](https://docs.stackhawk.com/stackhawk-cli).
 
 ## Install
-```shell
-$ brew tap stackhawk/cli
-$ brew install hawk
+
+```sh
+brew tap stackhawk/cli
 ```
 
+### HawkScan
 
+```sh
+brew install hawk
+```
+
+### HawkOp
+
+```sh
+brew install hawkop
+```


### PR DESCRIPTION
## Summary

- Add a HawkOp install section alongside the existing HawkScan one. Both formulas now live in this tap; users tap `stackhawk/cli` and `brew install` either.

## Test plan

- [ ] Render preview of README on the PR matches expected layout